### PR TITLE
Expose TLS settings for DB connection

### DIFF
--- a/sys/database/service.go
+++ b/sys/database/service.go
@@ -11,6 +11,16 @@ import (
 	"github.com/68696c6c/goat/sys/log"
 )
 
+type TLSMode string
+
+const (
+	TLSModeNone       = ""
+	TLSModeSkipVerify = "skip-verify"
+	TLSModePreferred  = "preferred"
+	TLSModeStrict     = "true"
+	TLSModeOff        = "false"
+)
+
 type Config struct {
 	Debug    bool
 	Host     string
@@ -18,6 +28,7 @@ type Config struct {
 	Database string
 	Username string
 	Password string
+	TLS      TLSMode
 }
 
 func (c Config) String() string {
@@ -25,7 +36,12 @@ func (c Config) String() string {
 }
 
 func (c Config) ConnectionString() string {
-	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=true", c.Username, c.Password, c.Host, c.Port, c.Database)
+	base := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4&parseTime=true", c.Username, c.Password, c.Host, c.Port, c.Database)
+	if c.TLS != "" {
+		base += fmt.Sprintf("&tls=%s", string(c.TLS))
+	}
+
+	return base
 }
 
 type Service interface {

--- a/sys/database/service_test.go
+++ b/sys/database/service_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -21,6 +22,35 @@ func Test_Service_GetMainDB(t *testing.T) {
 	db, err := subject.GetMainDB()
 	require.Nil(t, err)
 	require.NotNil(t, db)
+}
+
+func Test_Service_ConnectionStringTLS(t *testing.T) {
+	cases := []struct {
+		name          string
+		mode          TLSMode
+		expectedValue string
+	}{
+		{"default tls", TLSMode(""), ""},
+		{"strict", TLSModeStrict, "true"},
+		{"skip verify", TLSModeSkipVerify, "skip-verify"},
+		{"preferred", TLSModePreferred, "preferred"},
+		{"off", TLSModeOff, "false"},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			conf := Config{Host: "h", Port: 3306, Username: "u", Password: "p", Database: "d"}
+			if testCase.mode != "" {
+				conf.TLS = testCase.mode
+			}
+
+			dsn := conf.ConnectionString()
+			parsed, err := url.Parse(dsn)
+
+			require.NoError(t, err)
+			require.Equal(t, testCase.expectedValue, parsed.Query().Get("tls"))
+		})
+	}
 }
 
 func Test_Service_GetMainDB_Invalid(t *testing.T) {


### PR DESCRIPTION
It might be better to refactor this to just allow the user to pass a DSN or *mysql.Config directly, rather than trying to re-implement those things.