### PR TITLE
feat: add log handler warn

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,7 +1,6 @@
 package goat
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -23,7 +22,11 @@ func debugError(err error) error {
 }
 
 func logHandlerError(cx *gin.Context, err error) {
-	GetLogger().Error(fmt.Sprintf("%s | %s", cx.HandlerName(), err))
+	GetLogger().With("error", err, "handler", cx.HandlerName).Errorf("%s | %s", cx.HandlerName(), err)
+}
+
+func logHandlerWarn(cx *gin.Context, err error) {
+	GetLogger().With("error", err, "handler", cx.HandlerName).Warnf("%s | %s", cx.HandlerName(), err)
 }
 
 func RespondOk(cx *gin.Context, data any) {
@@ -48,31 +51,31 @@ func RespondCreated(cx *gin.Context, data any) {
 
 func RespondNotFound(cx *gin.Context, err error) {
 	status := http.StatusNotFound
-	logHandlerError(cx, err)
+	logHandlerWarn(cx, err)
 	cx.AbortWithStatusJSON(status, hal.NewApiProblem(status, debugError(err)))
 }
 
 func RespondBadRequest(cx *gin.Context, err error) {
 	status := http.StatusBadRequest
-	logHandlerError(cx, err)
+	logHandlerWarn(cx, err)
 	cx.AbortWithStatusJSON(status, hal.NewApiProblem(status, debugError(err)))
 }
 
 func RespondValidationError(cx *gin.Context, err error) {
 	status := http.StatusBadRequest
-	logHandlerError(cx, err)
+	logHandlerWarn(cx, err)
 	cx.AbortWithStatusJSON(status, hal.NewApiProblem(status, err))
 }
 
 func RespondUnauthorized(cx *gin.Context, err error) {
 	status := http.StatusUnauthorized
-	logHandlerError(cx, err)
+	logHandlerWarn(cx, err)
 	cx.AbortWithStatusJSON(status, hal.NewApiProblem(status, debugError(err)))
 }
 
 func RespondForbidden(cx *gin.Context, err error) {
 	status := http.StatusForbidden
-	logHandlerError(cx, err)
+	logHandlerWarn(cx, err)
 	cx.AbortWithStatusJSON(status, hal.NewApiProblem(status, debugError(err)))
 }
 


### PR DESCRIPTION
# Add Warning Logging

Currently, `goat` logs errors if handlers call the following status functions:

```go
RespondNotFound()
RespondBadRequest()
RespondValidationError()
RespondUnauthorized()
RespondForbidden()
```

In log management software these errors can quickly dilute the importance of actual 500's for example.

Clearly 400-499 codes means something went wrong, we just don't know if it is the client or `goat`, thus I propose to move 400-499 logging to the warning log status.

I also added the `.With()` clause to both error and warn logging to allow for structured log parsers to sort by handler or error type. 

There is a also a simplification of the string formatting. Before the string was formatted with `fmt` but the `zap.SuggaredLogger` has a `Errorf` and `Warnf` variant that does the same as `.Error(fmt.Sprintf("...", ...))`